### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,10 +48,5 @@
     "jshint": "^2.5.10",
     "jshint-stylish": "^1.0.0"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/MIT"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
